### PR TITLE
Add classes to Hiera

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,3 +1,4 @@
 ---
 classes:
-  - base
+  - base::mounts
+  - base::packages


### PR DESCRIPTION
Instead of an init.pp script, this commit uses Hiera as a lightweight ENC to tell Puppet which modules to autoload. Initially, I tested with defining `base` as a class, but this didn't work too well. Declaring `base::{class_name}` explicitly works much better.
