### PR TITLE
Add puppet modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,14 +3,3 @@ forge 'http://forge.puppetlabs.com/'
 mod 'puppetlabs/stdlib', '~> 3.0'
 mod 'puppetlabs/apt', '~> 1.4.2'
 mod 'attachmentgenie/ufw', '~> 1.1.0'
-mod 'attachmentgenie/ssh', '~> 1.1.1'
-mod 'blom/rssh'
-
-mod 'clamav',
-  :git  =>  'git://github.com/alphagov/puppet-clamav.git'
-mod 'ext4mount',
-  :git  =>  'git://github.com/alphagov/puppet-ext4mount.git'
-mod 'harden',
-  :git  =>  'git://github.com/alphagov/puppet-harden.git'
-mod 'lvm',
-  :git  =>  'git://github.com/alphagov/puppetlabs-lvm.git'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,8 +1,14 @@
 FORGE
   remote: http://forge.puppetlabs.com/
   specs:
+    attachmentgenie/ufw (1.1.0)
+      puppetlabs/stdlib (>= 2.2.1)
+    puppetlabs/apt (1.4.2)
+      puppetlabs/stdlib (>= 2.2.1)
     puppetlabs/stdlib (3.2.0)
 
 DEPENDENCIES
+  attachmentgenie/ufw (~> 1.1.0)
+  puppetlabs/apt (~> 1.4.2)
   puppetlabs/stdlib (~> 3.0)
 


### PR DESCRIPTION
This pull request adds:
- `puppetlabs/apt` to allow Puppet (and, soon, unattended upgrades) to control package updates
- `attachmentgenie/ufw` to allow for management of ufw firewall rules using Puppet
- `attachmentgenie/ssh` to allow for management of SSH using Puppet
- `blom/rssh` to lock `govuk-backup` user to a shell which only allows rsync
- `alphagov/lvm` to allow configuration of LVM drives via Puppet
- `alphagov/puppet-ext4mount` to allow mounting of ext4 drives via Puppet
- `alphagov/puppet-harden` to harden Ubuntu installation
- `alphagov/puppet-clamav` to install and manage ClamAV via Puppet
