### PR TITLE
Add base::packages to Hiera

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,3 +1,3 @@
 ---
 classes:
-  -
+  - base::packages


### PR DESCRIPTION
This commit adds base::packages class to Hiera. The packages class installs
packages which the machine needs to run. For details, see PR #4.
