### PR TITLE
Allow 'sudo' group to sudo w/o password auth

### DIFF
--- a/modules/base/manifests/user.pp
+++ b/modules/base/manifests/user.pp
@@ -14,4 +14,8 @@ class base::user (
     ssh_key      => $ssh_key,
   }
 
+  sudo::conf { 'sudo_nopasswd':
+    priority     => 10,
+    content      => '%sudo ALL=(ALL) NOPASSWD: ALL',
+  }
 }


### PR DESCRIPTION
This commit allows those users in the 'sudo' group to escalate their privileges
without authentication. Whilst this may not seem an ideal situation, being able
to run commands on the remote off-site backup box as sudo is important in order
to ensure that users are not locked out of the box and have some control over
its workings.

Whilst, in principle, this is not a particularly nice idea, it foregos the
notion of us having to store a secret somewhere: if we did this in Hiera, we
would need to hash it sufficiently; if we stored this secret elsewhere, we would
need a deployment repository solely for one password. And we can't store it on
the box for obvious security reasons.
