### PR TITLE
Amend rSSH allowed programs

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -85,7 +85,7 @@ apt::unattended_upgrades::mail_to: 'machine.email@digital.cabinet-office.gov.uk'
 base::user::ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAAAgQDM1YJkjk/n9JaiepLnDNqB3yBR7gNUITz3EenyRoNy1udi4MVr3m4FFbYEWGCMvyjF/rLdvZT7rE1cRQfDHn0VQcB9+eO7jjaCtk5nz/+mDrtQq+dWWidg2R4cBfnDmyY/JP44ZkKx/TcXzILBRfOuAE3JfYbcgXScl95OmeOdyw==
 
 rssh::allow:
-  - rsync
+  - scp
 
 ufw::allows:
   ssh:


### PR DESCRIPTION
This commit amends the programs which rSSH allows to be run under users using it
as their shell from `rsync` to `scp`, as we are now using this in the
offsite-backup script.
