### PR TITLE
Pin to Puppet 3.4 and Facter 1.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source 'https://rubygems.org'
 # advisable to pin major versions in this Gemfile.
 
 # Puppet core.
-gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.1.0'
-gem 'facter', ENV['FACTER_VERSION'] || '~> 1.6.0'
+gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.4.0'
+gem 'facter', ENV['FACTER_VERSION'] || '~> 1.7.0'
 
 # Dependency management.
 gem 'librarian-puppet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     builder (3.2.2)
     diff-lcs (1.2.4)
     excon (0.32.1)
-    facter (1.6.18)
+    facter (1.7.5)
     fog (1.21.0)
       fog-brightbox
       fog-core (~> 1.21, >= 1.21.1)
@@ -34,11 +34,11 @@ GEM
       multi_json (~> 1.0)
     formatador (0.2.4)
     hashdiff (0.1.1)
-    hiera (1.2.1)
+    hiera (1.3.2)
       json_pure
     highline (1.6.21)
     json (1.8.1)
-    json_pure (1.8.0)
+    json_pure (1.8.1)
     librarian (0.1.2)
       highline
       thor (~> 0.15)
@@ -62,9 +62,10 @@ GEM
     open3_backport (0.0.3)
       open4 (~> 1.3.0)
     open4 (1.3.3)
-    puppet (3.1.1)
+    puppet (3.4.3)
       facter (~> 1.6)
       hiera (~> 1.0)
+      rgen (~> 0.6.5)
     puppet-lint (0.3.2)
     puppet-syntax (0.0.4)
       puppet (>= 2.7.0)
@@ -75,6 +76,7 @@ GEM
       rspec (>= 2.9.0)
       rspec-puppet (>= 0.1.1)
     rake (10.0.4)
+    rgen (0.6.6)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -103,9 +105,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  facter (~> 1.6.0)
+  facter (~> 1.7.0)
   librarian-puppet
-  puppet (~> 3.1.0)
+  puppet (~> 3.4.0)
   puppet-lint (~> 0.3.0)
   puppet-syntax
   puppetlabs_spec_helper (~> 0.4.0)

--- a/tools/bootstrap
+++ b/tools/bootstrap
@@ -9,4 +9,4 @@ if ! dpkg -l puppetlabs-release >/dev/null; then
   apt-get update -qq
 fi
 
-apt-get install -y -qq --no-upgrade ruby1.9.1 puppet='3.2.*' puppet-common='3.2.*'
+apt-get install -y -qq --no-upgrade ruby1.9.3 puppet='3.4.*' puppet-common='3.4.*' facter='1.7.*'

--- a/vcloud/box/common/bootstrap.erb
+++ b/vcloud/box/common/bootstrap.erb
@@ -28,7 +28,7 @@ if [ $1 = "postcustomization" ]; then
   apt-get update
   
   export PATH=$PATH:/usr/local/bin
-  apt-get -y install puppet ruby1.9.3
+  apt-get -y install ruby1.9.3 puppet='3.4.*' puppet-common='3.4.*' facter='1.7.*'
   service puppet stop
   DISKS=`ls /dev/sd? | tail -n +2`
   


### PR DESCRIPTION
So that we are consistently using the same version (which is at the time of
writing latest stable and what we use on GOV.UK) instead of picking the
latest from the PuppetLabs repo at provisioning time.

This doesn't address managing the version of Puppet for existing machines.
We probably want to use alphagov/puppet-puppet

---

Much duplication :(
