### PR TITLE
Remove unused DISKS partitioning line

### DIFF
--- a/vcloud/box/common/bootstrap.erb
+++ b/vcloud/box/common/bootstrap.erb
@@ -28,6 +28,5 @@ if [ $1 = "postcustomization" ]; then
   export PATH=$PATH:/usr/local/bin
   apt-get -y install puppet ruby1.9.3
   service puppet stop
-  DISKS=`ls /dev/sd? | tail -n +2`
   
 fi


### PR DESCRIPTION
The line being removed from the bootstrap script listed all block-list devices
in /dev/ beginning sd*. Since we no longer do disk partitioning here, we no
longer need this.
