### PR TITLE
Amend disk size from 50gb to 300gb

### DIFF
--- a/vcloud/box/carrenza/govuk_offsitebackups.yaml
+++ b/vcloud/box/carrenza/govuk_offsitebackups.yaml
@@ -13,7 +13,7 @@ vapps:
       ip_address: '192.168.152.10'
     extra_disks:
     - name: backup-disk
-      size: 51200
+      size: 307200
     bootstrap:
         script_path: 'vcloud/box/common/bootstrap.erb'
         vars:


### PR DESCRIPTION
Given that we are required to keep thirty days of back-ups, and that each of
these is approximately 5gb to 6gb in size, we should re-size /srv/backup-disk
appropriately.
