### PR TITLE
Don't write Fog credentials to disk

### DIFF
--- a/vcloud/box/carrenza/fog_credentials.rb
+++ b/vcloud/box/carrenza/fog_credentials.rb
@@ -1,0 +1,17 @@
+# Initialiser for getting vCloud credentials into Fog from Jenkins build
+# parameters, without needing to write them to disk. To be used with:
+#
+#     RUBYOPT="-r ./tools/fog_credentials" bundle exec vcloud-launch …
+#
+# Replace with FOG_VCLOUD_TOKEN support when we have a tool:
+#
+#     https://www.pivotaltracker.com/story/show/68989754
+#
+require 'bundler/setup'
+require 'fog'
+
+Fog.credentials = {
+  :vcloud_director_host     => 'myvdc.carrenza.net',
+  :vcloud_director_username => "#{ENV['VCLOUD_USER']}@0e7t-infrastructure-services",
+  :vcloud_director_password => ENV['VCLOUD_PASS'],
+}

--- a/vcloud/box/carrenza/generate_fogfile.sh
+++ b/vcloud/box/carrenza/generate_fogfile.sh
@@ -1,6 +1,0 @@
-cat <<EOF >fog_cred.config
-default:
-  vcloud_director_username: $VCLOUD_USER@0e7t-infrastructure-services
-  vcloud_director_password: $VCLOUD_PASS
-  vcloud_director_host: 'myvdc.carrenza.net'
-EOF

--- a/vcloud/box/carrenza/jenkins.sh
+++ b/vcloud/box/carrenza/jenkins.sh
@@ -2,13 +2,8 @@
 set -eu
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 
-${WORKSPACE}/vcloud/box/carrenza/generate_fogfile.sh
-export FOG_RC=${WORKSPACE}/fog_cred.config
-
-bundle exec vcloud-launch vcloud/box/carrenza/govuk_offsitebackups.yaml
+RUBYOPT="-r ./vcloud/box/carrenza/fog_credentials" bundle exec vcloud-launch vcloud/box/carrenza/govuk_offsitebackups.yaml
 logger -p INFO -t jenkins "DEPLOYMENT: ${JOB_NAME} ${BUILD_NUMBER}
 (${BUILD_URL})"
 bundle exec vcloud-configure-edge vcloud/net/carrenza/edge.yaml
 logger -p INFO -t jenkins "Configuring ${BUILD_NUMBER}'s network settings..."
-echo "Removing Fog file..."
-rm fog_cred.config


### PR DESCRIPTION
Read fog credentials directly from environment variables rather than writing
them to disk. This is generally more secure, but also addresses a race
condition (of sorts) whereby the credential file will be left if
`vcloud-launch` were to exit with a non-zero status.

All existing environment variable names have been preserved so that no
changes to the existing Jenkins job is necessary.

Borrowed from gds/pp-pilotis - should be replaced with an authentication
token when [#68989754] provides a generic tool to do so.
