### PR TITLE
No longer explicitly define Puppet versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ before_install: rm Gemfile.lock
 rvm:
   - 1.9.3
   - ruby-head
-env:
-  - PUPPET_VERSION="~> 3.1.0"
-  - PUPPET_VERSION="~> 3.2.0"
 matrix:
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
By not explicitly defining Puppet versions in `.travis.yml`, when Travis
runs, it will run against the latest version in the repository's Gemfile.

This means that when we upgrade Puppet on this box, the integration tests
should update automagically.
