### PR TITLE
Revert `ecac72c`

### DIFF
--- a/vcloud/net/carrenza/edge.yaml
+++ b/vcloud/net/carrenza/edge.yaml
@@ -31,11 +31,6 @@ firewall_service:
       destination_ip: "31.210.241.201"
       source_ip: "37.26.90.227"
       destination_port_range: "22"
-    - description: "SSH access from offsite-backup.production"
-      protocols: tcp
-      destination_ip: "31.210.241.201"
-      source_ip: "78.31.106.101"
-      destination_port_range: "22"
     - description: "NRPE access from monitoring-1.management.production" 
       protocols: tcp
       destination_ip: "31.210.241.201"


### PR DESCRIPTION
This commit reverts the firewall changes made in ecac72c to allow us to
copy old off-site backup data from the Memset MiniServer VM to the new
Carrenza machine. After merging, this needs [re-deploying](https://github.com/alphagov/govuk_offsitebackups-puppet#deployment).
