### PR TITLE
Add a disk for log backups.

### DIFF
--- a/vcloud/box/carrenza/govuk_offsitebackups.yaml
+++ b/vcloud/box/carrenza/govuk_offsitebackups.yaml
@@ -14,6 +14,8 @@ vapps:
     extra_disks:
     - name: backup-disk
       size: 307200
+    - name: logs-disk
+      size: 524288
     bootstrap:
         script_path: 'vcloud/box/common/bootstrap.erb'
         vars:


### PR DESCRIPTION
Add a 512GB disk for transition log backups.
