### PR TITLE
Allow ssh from ci-new

### DIFF
--- a/vcloud/net/carrenza/edge.yaml
+++ b/vcloud/net/carrenza/edge.yaml
@@ -36,6 +36,11 @@ firewall_service:
       destination_ip: "31.210.241.201"
       source_ip: "37.26.90.227"
       destination_port_range: 5666
+    - description: "SSH access from transition-logs-1"
+      protocols: tcp
+      destination_ip: "31.210.241.201"
+      source_ip: "37.26.93.132"
+      destination_port_range: "22"
 nat_service:
   enabled: true
   nat_rules:


### PR DESCRIPTION
this is to allow backup of transition logs.
