### PR TITLE
Stringify NRPE port in VSE rule

### DIFF
--- a/vcloud/net/carrenza/edge.yaml
+++ b/vcloud/net/carrenza/edge.yaml
@@ -35,7 +35,7 @@ firewall_service:
       protocols: tcp
       destination_ip: "31.210.241.201"
       source_ip: "37.26.90.227"
-      destination_port_range: 5666
+      destination_port_range: "5666"
     - description: "SSH access from transition-logs-1"
       protocols: tcp
       destination_ip: "31.210.241.201"


### PR DESCRIPTION
To fix schema validation error:

```
E, [2014-05-09T09:54:01.995771 #6275] ERROR -- : Supplied configuration does not match supplied schema
F, [2014-05-09T09:54:01.995619 #6275] FATAL -- : destination_port_range: 5666 is not a string
```
