### PR TITLE
Fix NRPE command

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -5,6 +5,7 @@ classes:
   - apt::unattended_upgrades
   - base::clamav
   - base::mounts
+  - base::nrpe
   - base::user
   - clamav
   - harden
@@ -93,11 +94,6 @@ base::user::logs_ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQDEBXBO6UU0zkOM+RL3TTir0Z
 nrpe::allowed_hosts:
   - 127.0.0.1
   - 37.26.90.227
-
-nrpe::commands:
-  check_disk:
-    ensure  => present
-    command => 'check_disk -w 20% -c 10% /srv/backup-data'
 
 # Carrenza nameservers.
 resolvconf::nameservers:

--- a/modules/base/manifests/nrpe.pp
+++ b/modules/base/manifests/nrpe.pp
@@ -1,0 +1,12 @@
+# == Class: base::nrpe
+#
+# This class defines NRPE commands to be used with the pdxcat/nrpe module
+# this repository uses.
+
+class base::nrpe{
+
+    nrpe::command {'check_disk':
+        ensure  => present,
+        command => 'check_disk -w 20% -c 10% /srv/backup-data',
+    }
+}


### PR DESCRIPTION
Currently, the NRPE command which checks for available disk space is failing. It tells us that `check_disk` is not defined. This pull request fixes that, as it was originally thought/assumed that the pdxcat/nrpe module in use would allow the definition of checks in Hiera.
