### PR TITLE
Switch from `-delete` to a `-exec`

### DIFF
--- a/modules/base/files/usr/local/sbin/rotate-tarballs.sh
+++ b/modules/base/files/usr/local/sbin/rotate-tarballs.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-find /srv/backup-data -not \( -path /srv/backup-data/lost+found -prune \) -type f -mtime +30 -delete
+find /srv/backup-data -not \( -path /srv/backup-data/lost+found -prune \) -type f -mtime +30 -exec rm {} +


### PR DESCRIPTION
This commit changes the `find` command we run on a cron to switch from
`-delete` to `exec rm {} +`. The reasoning for this is that using `-delete`
results in an error:

`find: The -delete action atomatically turns on -depth, but -prune does
nothing when -depth is in effect.  If you want to carry on anyway, just
explicitly use the -depth option`

See also: issue https://github.com/alphagov/govuk_offsitebackups-puppet/issues/50
