### PR TITLE
Force `rm` to delete files w/o confirmation

### DIFF
--- a/modules/base/files/usr/local/sbin/rotate-tarballs.sh
+++ b/modules/base/files/usr/local/sbin/rotate-tarballs.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-find /srv/backup-data -not \( -path /srv/backup-data/lost+found -prune \) -type f -mtime +30 -exec rm {} +
+find /srv/backup-data -not \( -path /srv/backup-data/lost+found -prune \) -type f -mtime +30 -exec rm -f {} +


### PR DESCRIPTION
This commit adds the `-f` switch to `rm` in order to force removal of files
with an mtime >30 days. Without the `-f` flag, the command prompts - if this
were happening automatically in a cron job, files would never be removed as
no confirmation would be given automatically.
