### PR TITLE
Alphabetise dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,22 +4,22 @@ source 'https://rubygems.org'
 # Travis will remove Gemfile.lock before installing deps. As such, it is
 # advisable to pin major versions in this Gemfile.
 
-# Puppet core.
-gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.4.0'
-gem 'facter', ENV['FACTER_VERSION'] || '~> 1.7.0'
-
 # Dependency management.
 gem 'librarian-puppet'
 
+# Puppet core.
+gem 'facter', ENV['FACTER_VERSION'] || '~> 1.7.0'
+gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.4.0'
+
 # Testing utilities.
-gem 'rake'
 gem 'puppet-syntax'
 gem 'puppet-lint', '~> 0.3.0'
-gem 'rspec-puppet', '~> 0.1.0'
 gem 'puppetlabs_spec_helper', '~> 0.4.0'
+gem 'rake'
+gem 'rspec-puppet', '~> 0.1.0'
 
 # vCloud tools
-gem 'vcloud-walker'
 gem 'vcloud-core'
 gem 'vcloud-edge_gateway'
 gem 'vcloud-tools', :github => 'alphagov/vcloud-tools'
+gem 'vcloud-walker'

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,23 +1,23 @@
 forge 'http://forge.puppetlabs.com/'
 
-mod 'puppetlabs/stdlib', '~> 3.0'
-mod 'puppetlabs/apt', '~> 1.4.2'
-mod 'blom/rssh'
 mod 'attachmentgenie/ssh', '~> 1.1.1'
 mod 'attachmentgenie/ufw'
-mod 'pdxcat/nrpe'
+mod 'blom/rssh'
 mod 'gdsoperations/resolvconf'
+mod 'pdxcat/nrpe'
+mod 'puppetlabs/apt', '~> 1.4.2'
+mod 'puppetlabs/stdlib', '~> 3.0'
 
+mod 'clamav',
+  :git  => 'git://github.com/alphagov/puppet-clamav.git'
+mod 'ext4mount',
+  :git  =>  'git://github.com/alphagov/puppet-ext4mount.git'
 mod 'gds_accounts',
   :git => 'git://github.com/alphagov/puppet-gds_accounts.git',
   :ref => 'v1.0.0'
-mod 'lvm',
-  :git  =>  'git://github.com/alphagov/puppetlabs-lvm.git'
-mod 'ext4mount',
-  :git  =>  'git://github.com/alphagov/puppet-ext4mount.git'
-mod 'clamav',
-  :git  => 'git://github.com/alphagov/puppet-clamav.git'
 mod 'harden',
     :git => 'git://github.com/alphagov/puppet-harden.git'
+mod 'lvm',
+  :git  =>  'git://github.com/alphagov/puppetlabs-lvm.git'
 mod 'sudo',
     :git => 'git://github.com/alphagov/puppet-sudo.git'


### PR DESCRIPTION
The dependencies in this repository have been a bit of a mess for a while. Tidying them up makes it easier to find stuff. Since this is just tidying things up, I can't see any functional changes (detrimental or otherwise) - both the Puppetfile and Gemfile (and their respective lockfiles) look fine, as expected (as there are no changes).
