### PR TITLE
Make -u option for fab more prominent

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,4 @@ original glory once it has the chance to run successfully.
 If it's not the first time you are applying this repository to a machine, you
 can run:
 
-`fab -c /dev/null production deploy`
-
-The `-u` switch can be used, along with a username, to specify your username
-on the remote back-up machine if this differs from your local username, as
-follows:
-
-`fab -u {username} -c /dev/null production deploy`
+`fab -c /dev/null -u YOUR_SSH_USERNAME production deploy`


### PR DESCRIPTION
I missed the last paragraph when trying to deploy Puppet and was
prompted for a password because my local username differs from my
account on this box.

Make the -u option more prominent to avoid this in future.
