### PR TITLE
Allow Rsync access through rSSH

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -106,6 +106,7 @@ resolvconf::nameservers:
   - 195.225.219.97
 
 rssh::allow:
+  - rsync
   - scp
   - sftp
 


### PR DESCRIPTION
When backing up assets and Whitehall using Duplicity, I originally used SCP
which makes use of the Paramiko back-end (as it's all Python) for SSH
access. Due to https://github.com/paramiko/paramiko/issues/49 and
https://github.com/paramiko/paramiko/issues/63, we can't use Paramiko.

Changing the SSH backend in the version of Duplicity we run (0.6.18) isn't
supported. It is in later versions, but they aren't available from Ubuntu
for Precise machines. As a result, we need to ensure that rSSH allows access
for Rsync.

This does that.
