### PR TITLE
Ensure assets backup targets exist

### DIFF
--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -52,6 +52,18 @@ class base::mounts {
         owner   => 'govuk-assets',
     }
 
+    file { '/srv/backup-assets/whitehall':
+        ensure  => directory,
+        owner   => 'govuk-assets',
+        group   => 'govuk-assets',
+    }
+
+    file { '/srv/backup-assets/asset-manager':
+        ensure  => directory,
+        owner   => 'govuk-assets',
+        group   => 'govuk-assets',
+    }
+
     lvm::volume { 'assets':
         ensure  => present,
         pv      => '/dev/sdd',


### PR DESCRIPTION
If these don't already exist, Rsync will fail as it won't create them. We
also need to set appropriate ownership on the directories, else
permissions-related errors occur and Rsync will halt.
