### PR TITLE
Check free disk space on /srv/backup-assets

### DIFF
--- a/modules/base/manifests/nrpe.pp
+++ b/modules/base/manifests/nrpe.pp
@@ -17,4 +17,8 @@ class base::nrpe{
         ensure  => present,
         command => 'check_disk -w 10% -c 5% /srv/backup-data',
     }
+    nrpe::command {'check_disk_backup-assets':
+        ensure  => present,
+        command => 'check_disk -w 10% -c 5% /srv/backup-assets',
+    }
 }


### PR DESCRIPTION
Since we're now backing assets up to this drive, and it's in use in
production, we should start to monitor the drive for free disk space.

Duplicity should take care of disk space for us, but it's better to be safe
than sorry.
