### PR TITLE
Change disk name

### DIFF
--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -42,7 +42,7 @@ class base::mounts {
 
     ext4mount { '/srv/backup-logs':
         mountoptions  =>  'defaults',
-        disk          =>  '/dev/mapper/logs-backup',
+        disk          =>  '/dev/mapper/logsbackup-backup',
         before        =>  File['/srv/backup-logs'],
         require       =>  Lvm::Volume['backup'],
     }


### PR DESCRIPTION
In order to deploy https://github.com/alphagov/govuk_offsitebackups-puppet/pull/70, we need to rename the volume group in Puppet to match the name of the disk in /dev/mapper on the box.
