### PR TITLE
Document fabric requirement better

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ virtual machine (to destroy it) if you wish to make another change, unless
 it is trivial - in which case you can run `vagrant provision obnode0` to
 re-run Puppet against it.
 
+## Deployment Setup - Install Fabric (ideally in a virtualenv)
+
+    `pip install -r requirements.txt`
+
 ## Deployment
 
 If this is the first time that this repository is being applied to a machine,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Fabric==1.10.0
+ecdsa==0.11
+paramiko==1.15.1
+pycrypto==2.6.1
+wsgiref==0.1.2


### PR DESCRIPTION
We mention using fabric under deployment. We don't say how to install
it, nor do we hint that virtualenvs are the right way to do it.

This is slightly better.
