### PR TITLE
Switch from alphagov/puppet-sudo to saz/sudo

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,6 +7,7 @@ mod 'gdsoperations/resolvconf'
 mod 'pdxcat/nrpe'
 mod 'puppetlabs/apt', '~> 1.4.2'
 mod 'puppetlabs/stdlib', '~> 3.0'
+mod 'saz/sudo', '~> 3.0.1'
 
 mod 'clamav',
   :git  => 'git://github.com/alphagov/puppet-clamav.git'
@@ -19,5 +20,3 @@ mod 'harden',
     :git => 'git://github.com/alphagov/puppet-harden.git'
 mod 'lvm',
   :git  =>  'git://github.com/alphagov/puppetlabs-lvm.git'
-mod 'sudo',
-    :git => 'git://github.com/alphagov/puppet-sudo.git'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -17,6 +17,8 @@ FORGE
     puppetlabs/apt (1.4.2)
       puppetlabs/stdlib (>= 2.2.1)
     puppetlabs/stdlib (3.2.1)
+    saz/sudo (3.0.1)
+      puppetlabs/stdlib (>= 2.3.0)
 
 GIT
   remote: git://github.com/alphagov/puppet-clamav.git
@@ -50,14 +52,6 @@ GIT
     harden (0.0.1)
 
 GIT
-  remote: git://github.com/alphagov/puppet-sudo.git
-  ref: master
-  sha: 62b93dacbf49ac82022e52ef7046c467f1c21cf5
-  specs:
-    sudo (3.0.1)
-      puppetlabs/stdlib (>= 2.3.0)
-
-GIT
   remote: git://github.com/alphagov/puppetlabs-lvm.git
   ref: master
   sha: 2082a276093c96e67a676f0c6076c0841f918a17
@@ -77,5 +71,5 @@ DEPENDENCIES
   pdxcat/nrpe (>= 0)
   puppetlabs/apt (~> 1.4.2)
   puppetlabs/stdlib (~> 3.0)
-  sudo (>= 0)
+  saz/sudo (~> 3.0.1)
 


### PR DESCRIPTION
This repo was originally using arnouj/sudo but was switched to a git
reference to alphagov/puppet-sudo which was forked from saz/sudo at
version 3.0.1.

There is absolutely no point this repo referring to an outdated fork to
which we have made no changes, so I am changing the Puppetfile to
reference `saz/sudo ~> 3.0.1` in common with our other repos.

This is for story [#77440542](https://www.pivotaltracker.com/story/show/77440542)
