### PR TITLE
Update vagrant box to 20141112 version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,8 @@ node_defaults = {
 }
 
 Vagrant.configure("2") do |config|
-  config.vm.box     = "govuk_dev_precise64_20140829"
-  config.vm.box_url = "http://gds-boxes.s3.amazonaws.com/govuk_dev_precise64_20140829.box"
+  config.vm.box     = "govuk_dev_precise64_2014112"
+  config.vm.box_url = "http://gds-boxes.s3.amazonaws.com/govuk_dev_precise64_20141112.box"
 
   config.vm.synced_folder '.', '/opt/puppet'
 


### PR DESCRIPTION
This is the latest version of our standard box. It brings no new
features relevant to this repository, but is being updated so we remain
consistent.
