### PR TITLE
Remove ClamAV

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -9,8 +9,6 @@ mod 'puppetlabs/apt', '~> 1.4.2'
 mod 'puppetlabs/stdlib', '~> 3.0'
 mod 'saz/sudo', '~> 3.0.1'
 
-mod 'clamav',
-  :git  => 'git://github.com/alphagov/puppet-clamav.git'
 mod 'ext4mount',
   :git  =>  'git://github.com/alphagov/puppet-ext4mount.git'
 mod 'gds_accounts',

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -21,14 +21,6 @@ FORGE
       puppetlabs/stdlib (>= 2.3.0)
 
 GIT
-  remote: git://github.com/alphagov/puppet-clamav.git
-  ref: master
-  sha: 8a60f4d537cd4e63bad0332daeabbc866f1fb7ff
-  specs:
-    clamav (0.0.2)
-      puppetlabs/stdlib (>= 3.0.0)
-
-GIT
   remote: git://github.com/alphagov/puppet-ext4mount.git
   ref: master
   sha: d97f99cc2801b83152b905d1285fa34e689cb499
@@ -62,7 +54,6 @@ DEPENDENCIES
   attachmentgenie/ssh (~> 1.1.1)
   attachmentgenie/ufw (>= 0)
   blom/rssh (>= 0)
-  clamav (>= 0)
   ext4mount (>= 0)
   gds_accounts (>= 0)
   gdsoperations/resolvconf (>= 0)

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -9,7 +9,6 @@ classes:
   - base::nrpe
   - base::supported_kernel
   - base::user
-  - clamav
   - harden
   - nrpe
   - resolvconf

--- a/modules/base/manifests/clamav.pp
+++ b/modules/base/manifests/clamav.pp
@@ -1,34 +1,36 @@
 # == Class: base::clamav
 #
-# Set up virus scanning of the backup-data drive
-# After all, we don't want a virus...
+# FIXME: Remove this class once deployed.
 #
 class base::clamav {
 
+  service { ['clamav-freshclam', 'clamav-daemon']:
+    ensure   => stopped,
+    provider => base,
+  } ->
+  package { ['clamav', 'clamav-base', 'clamav-freshclam', 'clamav-daemon']:
+    ensure => purged,
+  } ->
+  file { ['/etc/clamav/clamd.conf', '/etc/clamav/freshclam.conf']:
+    ensure => absent,
+  }
+
   file { '/srv/infected':
-    ensure => directory,
-    owner  => 'govuk-backup',
+    ensure => absent,
+    force  => true,
   }
 
   file { '/usr/local/sbin/scan-backup-data.sh':
-    require => File['/srv/infected'],
-    source  => 'puppet:///modules/base/usr/local/sbin/scan-backup-data.sh',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0755',
+    ensure  => absent,
   }
 
   file { '/etc/logrotate.d/clamdscan':
-    require => Package['clamav-daemon'],
-    source  => 'puppet:///modules/base/etc/logrotate.d/clamdscan',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+    ensure  => absent,
   }
 
   cron { 'clamscan-backup-data':
+    ensure  => absent,
     command => '/usr/local/sbin/scan-backup-data.sh',
     minute  => fqdn_rand(60),
-    require => File['/usr/local/sbin/scan-backup-data.sh'],
   }
 }


### PR DESCRIPTION
I'd like to stop ClamAV scanning and remove all traces of it from our office
backup machine because:
- the duplicity managed files on here are compressed and (in most cases)
  encrypted which makes scanning for viruses either slow or impossible
- it uses a lot of CPU and RAM on what is a relatively small machine
