### PR TITLE
[#80824874 #82210296] Remove backup rotation

### DIFF
--- a/modules/base/files/usr/local/sbin/rotate-tarballs.sh
+++ b/modules/base/files/usr/local/sbin/rotate-tarballs.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-find /srv/backup-data -not \( -path /srv/backup-data/lost+found -prune \) -type f -mtime +30 -exec rm -f {} +
-find /srv/backup-graphite -not \( -path /srv/backup-graphite/lost+found -prune \) -type f -mtime +3 -exec rm -f {} +

--- a/modules/base/manifests/rotate.pp
+++ b/modules/base/manifests/rotate.pp
@@ -1,23 +1,15 @@
 # rotate.pp
 #
-# This file defines the cron type and options in order to ensure that
-# backed-up data held on /srv/backup-data on off-site backup machines
-# is removed after thirty days.
-
+# FIXME: Remove class when deployed.
+#
 class base::rotate {
 
   file { '/usr/local/sbin/rotate-tarballs.sh':
-    source  => 'puppet:///modules/base/usr/local/sbin/rotate-tarballs.sh',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0755',
+    ensure => absent,
   }
 
   cron { 'rotate_old_backups':
-    require => File['/usr/local/sbin/rotate-tarballs.sh'],
-    command => '/usr/local/sbin/rotate-tarballs.sh',
-    user    => 'govuk-backup',
-    hour    => 09,
-    minute  => 00,
+    ensure => absent,
+    user   => 'govuk-backup',
   }
 }


### PR DESCRIPTION
This is done for us by the sender now that all offsite backups have been
converted to use duplicity.

By still having this cronned shell script in place we risk possibly deleting
duplicity's data underneath it and rendering a backup chain unusable.