### PR TITLE
[#75811634] Revoke session after deployment (+ update vers)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,33 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.2.8)
     builder (3.2.2)
     diff-lcs (1.2.4)
-    excon (0.39.4)
+    excon (0.42.1)
     facter (1.7.5)
-    fog (1.23.0)
-      fog-brightbox
-      fog-core (~> 1.23)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.25.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.25)
       fog-json
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-sakuracloud (>= 0.0.4)
       fog-softlayer
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
       ipaddress (~> 0.5)
       nokogiri (~> 1.5, >= 1.5.11)
-    fog-brightbox (0.3.0)
+      opennebula
+    fog-brightbox (0.7.1)
       fog-core (~> 1.22)
       fog-json
-      inflecto
-    fog-core (1.23.0)
+      inflecto (~> 0.0.2)
+    fog-core (1.25.0)
       builder
       excon (~> 0.38)
       formatador (~> 0.2)
@@ -25,11 +36,34 @@ GEM
       net-ssh (>= 2.1.3)
     fog-json (1.0.0)
       multi_json (~> 1.0)
-    fog-softlayer (0.3.13)
+    fog-profitbricks (0.0.1)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.3)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-sakuracloud (0.1.1)
       fog-core
       fog-json
+    fog-softlayer (0.3.25)
+      fog-core
+      fog-json
+    fog-terremark (0.0.3)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.0.1)
+      fission
+      fog-core
+    fog-voxel (0.0.2)
+      fog-core
+      fog-xml
+    fog-xml (0.1.1)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
-    hashdiff (0.2.1)
+    hashdiff (0.2.2)
     hiera (1.3.2)
       json_pure
     highline (1.6.21)
@@ -45,20 +79,24 @@ GEM
       librarian (>= 0.1.2)
       open3_backport
     metaclass (0.0.1)
-    mime-types (2.3)
-    mini_portile (0.6.0)
+    mime-types (2.4.3)
+    mini_portile (0.6.1)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
     multi_json (1.10.1)
-    mustache (0.99.6)
+    mustache (0.99.8)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.1)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
+    nokogiri (1.6.5)
+      mini_portile (~> 0.6.0)
     open3_backport (0.0.3)
       open4 (~> 1.3.0)
     open4 (1.3.3)
+    opennebula (4.10.1)
+      json
+      nokogiri
+      rbvmomi
     puppet (3.4.3)
       facter (~> 1.6)
       hiera (~> 1.0)
@@ -73,6 +111,10 @@ GEM
       rspec (>= 2.9.0)
       rspec-puppet (>= 0.1.1)
     rake (10.0.4)
+    rbvmomi (1.8.2)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
     rgen (0.6.6)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
@@ -85,27 +127,28 @@ GEM
     rspec-puppet (0.1.6)
       rspec
     thor (0.18.1)
-    vcloud-core (0.10.0)
-      fog (>= 1.22.0)
+    trollop (2.0)
+    vcloud-core (0.16.0)
+      fog (>= 1.25.0)
       highline
       mustache
-    vcloud-edge_gateway (1.1.0)
+    vcloud-edge_gateway (1.4.0)
       hashdiff
-      vcloud-core (~> 0.10.0)
-    vcloud-launcher (0.3.1)
-      vcloud-core (~> 0.10.0)
-    vcloud-net_launcher (0.5.1)
-      vcloud-core (~> 0.10.0)
+      vcloud-core (~> 0.16.0)
+    vcloud-launcher (0.7.0)
+      vcloud-core (~> 0.16.0)
+    vcloud-net_launcher (0.8.0)
+      vcloud-core (~> 0.16.0)
     vcloud-tools (1.0.0)
       vcloud-core
       vcloud-edge_gateway
       vcloud-launcher
       vcloud-net_launcher
       vcloud-walker
-    vcloud-walker (3.3.1)
+    vcloud-walker (3.6.0)
       fog (>= 1.21.0)
       json (~> 1.8.0)
-      vcloud-core (~> 0.10.0)
+      vcloud-core (~> 0.16.0)
 
 PLATFORMS
   ruby

--- a/vcloud/jenkins_vcloud_login.sh
+++ b/vcloud/jenkins_vcloud_login.sh
@@ -2,11 +2,12 @@
 set -eu
 
 function cleanup {
+  set +e
+  bundle exec vcloud-logout
   rm $FOG_RC
   unset FOG_RC
 }
 
-# Override default of ~/.fog and delete afterwards.
 export FOG_RC=$(mktemp /tmp/vcloud_fog_rc.XXXXXXXXXX)
 trap cleanup EXIT
 


### PR DESCRIPTION
Use the new `vcloud-logout` utility in vcloud-core 0.16.0 to revoke the
session token after we've deployed any changes.

This requires updating vcloud-core and all things that depend on it. I don't
have an easy way to test these locally, but I'll run each of the jobs in
after merging.