### PR TITLE
Add additional backup disks for Graphite and Assets

### DIFF
--- a/vcloud/box/carrenza/govuk_offsitebackups.yaml
+++ b/vcloud/box/carrenza/govuk_offsitebackups.yaml
@@ -22,6 +22,8 @@ vapps:
       size: 102400
     - name: assetsbackup-assets2
       size: 524288
+    - name: assetsbackup-assets3
+      size: 524288
     bootstrap:
         script_path: 'vcloud/box/common/bootstrap.erb'
         vars:

--- a/vcloud/box/carrenza/govuk_offsitebackups.yaml
+++ b/vcloud/box/carrenza/govuk_offsitebackups.yaml
@@ -24,6 +24,8 @@ vapps:
       size: 524288
     - name: assetsbackup-assets3
       size: 524288
+    - name: graphitebackup-graphite2
+      size: 102400
     bootstrap:
         script_path: 'vcloud/box/common/bootstrap.erb'
         vars:


### PR DESCRIPTION
In order to have enough disk space to support our new Duplicity policy of running a full backup weekly, we need to ensure that we have enough disk space to store more backups.