### PR TITLE
Remove firewall access from interim production

### DIFF
--- a/vcloud/net/carrenza/edge.yaml
+++ b/vcloud/net/carrenza/edge.yaml
@@ -21,11 +21,6 @@ firewall_service:
       destination_ip: "31.210.241.201"
       source_ip: "80.194.77.100"
       destination_port_range: "22"
-    - description: "SSH access from interim production"
-      protocols: tcp
-      destination_ip: "31.210.241.201"
-      source_ip: "217.171.99.70"
-      destination_port_range: "22"
     - description: "SSH access from P1 production"
       protocols: tcp
       destination_ip: "31.210.241.201"


### PR DESCRIPTION
Interim production does not exist any more, so we do not need
a firewall rule to allow access to the offsite backup machines
from there.