### PR TITLE
Update Puppet mounts

### DIFF
--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -65,7 +65,7 @@ class base::mounts {
     }
 
     # lvm::volume { 'assets':
-    $assets_disks = [ '/dev/sdd', '/dev/sdf' ]
+    $assets_disks = [ '/dev/sdd', '/dev/sdf', '/dev/sdg', '/dev/sdh' ]
     $assets_vgname = 'assetsbackup'
     $assets_lvname = 'assets'
     physical_volume { $assets_disks:
@@ -75,7 +75,10 @@ class base::mounts {
         ensure           => present,
         physical_volumes => $assets_disks,
         require          => [ Physical_volume['/dev/sdd'],
-                              Physical_volume['/dev/sdf']],
+                              Physical_volume['/dev/sdf'],
+                              Physical_volume['/dev/sdg'],
+                              Physical_volume['/dev/sdh'],
+                            ],
     }
     logical_volume { $assets_lvname:
         ensure       => present,


### PR DESCRIPTION
__UNTESTED CODE__

The list of disk mounts that Puppet is aware of is different to those on the
box. Thus, when Puppet is deployed, it tries to remove the disks it's not
aware of. Thankfully, it's not able to do this since the disks are mounted.

Adds /dev/sdg and /dev/sdh to the list of known mounts such that Puppet can
run on deployment.