### PR TITLE
Squash disks together

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -17,7 +17,8 @@ env.repo = 'git://github.com/alphagov/govuk_offsitebackups-puppet.git'
 def production():
     env.environment = 'production'
     env.hosts = [
-        'backup0.backup.provider1.production.govuk.service.gov.uk',
+        'backup0.backup.provider0.production.govuk.service.gov.uk',
+#       'backup0.backup.provider1.production.govuk.service.gov.uk',
         ]
 
 @task
@@ -49,7 +50,7 @@ def puppet_package():
     tempdir = tempfile.mkdtemp()
     atexit.register(shutil.rmtree, tempdir)
 
-    local('git clone %s %s/.' % (env.repo, tempdir))
+    local('git clone -b squash-disks %s %s/.' % (env.repo, tempdir))
 
     with lcd(tempdir):
         local('bundle install --quiet')

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,5 +1,5 @@
 :hierarchy:
-  - "node.%{::clientcert}"
+  - "node.%{::fqdn}"
   - "env.%{::environment}"
   - common
 :backends:

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,5 +1,6 @@
 :hierarchy:
-  - "node.%{::fqdn}"
+  - "node.backup0.backup.provider0.production.govuk.service.gov.uk"
+  - "node.backup0.backup.provider1.production.govuk.service.gov.uk"
   - "env.%{::environment}"
   - common
 :backends:

--- a/hieradata/env.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
+++ b/hieradata/env.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
@@ -1,0 +1,5 @@
+---
+
+base::mounts::assets_disks:
+  - '/dev/sdd'
+  - '/dev/sde'

--- a/hieradata/env.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
+++ b/hieradata/env.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
@@ -1,0 +1,6 @@
+---
+
+base::mounts::assets_disks:
+  - '/dev/sdd'
+  - '/dev/sdf'
+  - '/dev/sdg'

--- a/hieradata/env.development.yaml
+++ b/hieradata/env.development.yaml
@@ -1,5 +1,0 @@
----
-
-gds_accounts::purge_ignore:
-  - 'vagrant'
-  - 'vboxadd'

--- a/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
@@ -1,0 +1,5 @@
+---
+
+base::mounts::assets_disks:
+  - '/dev/sdd'
+  - '/dev/sde'

--- a/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
@@ -3,3 +3,6 @@
 base::mounts::assets_disks:
   - '/dev/sdd'
   - '/dev/sde'
+
+base::mounts::graphite_disks:
+  - '/dev/sdf'

--- a/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
@@ -4,3 +4,6 @@ base::mounts::assets_disks:
   - '/dev/sdd'
   - '/dev/sdf'
   - '/dev/sdg'
+
+base::mounts::graphite_disks:
+  - '/dev/sde'

--- a/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
@@ -1,0 +1,6 @@
+---
+
+base::mounts::assets_disks:
+  - '/dev/sdd'
+  - '/dev/sdf'
+  - '/dev/sdg'

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -11,4 +11,4 @@ PuppetLint.configuration.send('disable_class_parameter_defaults')
 # http://puppet-lint.com/checks/class_inherits_from_params_class/
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 # http://puppet-lint.com/checks/80chars/
-PuppetLint.configuration.send('disable_80chars_check')
+PuppetLint.configuration.send('disable_80chars')

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -10,3 +10,5 @@ PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('disable_class_parameter_defaults')
 # http://puppet-lint.com/checks/class_inherits_from_params_class/
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+# http://puppet-lint.com/checks/80chars/
+PuppetLint.configuration.send('disable_80chars_check')

--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -75,7 +75,7 @@ class base::mounts(
     volume_group { $assets_vgname:
         ensure           => present,
         physical_volumes => $assets_disks,
-        require          => Physical_volume[${assets_disks}],
+        require          => Physical_volume[$assets_disks],
     }
     logical_volume { $assets_lvname:
         ensure       => present,

--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -9,6 +9,7 @@
 
 class base::mounts(
   $assets_disks,
+  $graphite_disks,
 ){
 
     file { '/srv/backup-data':

--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -8,7 +8,7 @@
 # Always ensure `backup_data` directory exists
 
 class base::mounts(
-  assets_disks,
+  $assets_disks,
 ){
 
     file { '/srv/backup-data':
@@ -75,7 +75,7 @@ class base::mounts(
     volume_group { $assets_vgname:
         ensure           => present,
         physical_volumes => $assets_disks,
-        require          => Physical_volume["$assets_disks"],
+        require          => Physical_volume[${assets_disks}],
     }
     logical_volume { $assets_lvname:
         ensure       => present,

--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -49,11 +49,6 @@ class base::mounts(
         require       =>  Lvm::Volume['backup'],
     }
 
-    file { '/srv/backup-assets':
-        ensure  => directory,
-        owner   => 'govuk-assets',
-    }
-
     file { '/srv/backup-assets/whitehall':
         ensure  => directory,
         owner   => 'govuk-assets',

--- a/tools/puppet-apply
+++ b/tools/puppet-apply
@@ -6,4 +6,5 @@ sudo puppet apply \
   --hiera_config ${PUPPET_PATH}/hiera.yaml \
   --modulepath ${PUPPET_PATH}/modules:${PUPPET_PATH}/vendor/modules \
   ${PUPPET_PATH}/manifests/site.pp \
+  --debug \
   $@


### PR DESCRIPTION
We can pay down some tech debt and help mitigate against
https://github.com/gds-operations/vcloud-launcher/issues/104 by squashing
disks attached to the same volume group together in time for provisioning a
new off-site backup machine in Skyscape.

Currently, we use:

  - /dev/sda2 for the operating system
  - /dev/sdb for the backup volume group
  - /dev/sdc for the logsbackup volume group
  - /dev/sdd for the assetsbackup volume group
  - /dev/sde for the graphitebackup volume group
  - /dev/sdf for the assetsbackup volume group
  - /dev/sdg for the assetsbackup volume group
  - /dev/sdh for the graphitebackup volume group

We can squash /dev/sdd, /dev/sdf and /dev/sdg together to create a 1.5tb
disk, however since the LUN sizing on the SAN is set to 2tb at Skyscape,
it's recommended that we don't create disks over 1.8tb in size. There's some
overheard here, hence the difference between the LUN size and the
recommended maximum disk size. Instead, it looks best to squash them such
that we end up with two 768gb disks, which gives us about 1tb to grow if
required.

The proposal in this pull request is to use:

  - /dev/sda2 for the operating system
  - /dev/sdb for the backup volume group
  - /dev/sdc for the logsbackup volume group
  - /dev/sdd for the assetsbackup volume group (768gb)
  - /dev/sde for the assetsbackup volume group (768gb)
  - /dev/sdf for the graphitebackup volume group (256gb)

Increases the graphitebackup volume group's total size, too.