### PR TITLE
Ensure Travis builds run in containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 # Ignore lock file to facilitate matrix builds.
 before_install: rm Gemfile.lock
+# Explicitly ensure that we run on container-based infrastructure
+sudo: false
 rvm:
   - 1.9.3
   - ruby-head


### PR DESCRIPTION
Travis CI now supports containers as the default build infrastructure. For
builds running outside of containers, a warning is created for each build.
We can upgrade to the container-based infrastructure by adding this line to
the .travis.yml. The new infrastructure provides us with other build
benefits, too:
http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/