### PR TITLE
Change disk layout per provider

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,5 +1,5 @@
 :hierarchy:
-  - "node.%{::clientcert}"
+  - "node.%{::fqdn}"
   - "env.%{::environment}"
   - common
 :backends:

--- a/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
@@ -1,0 +1,5 @@
+---
+
+base::mounts::assets_disks:
+  - '/dev/sdd'
+  - '/dev/sde'

--- a/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
@@ -3,3 +3,6 @@
 base::mounts::assets_disks:
   - '/dev/sdd'
   - '/dev/sde'
+
+base::mounts::graphite_disks:
+  - '/dev/sdf'

--- a/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
@@ -4,3 +4,6 @@ base::mounts::assets_disks:
   - '/dev/sdd'
   - '/dev/sdf'
   - '/dev/sdg'
+
+base::mounts::graphite_disks:
+  - '/dev/sde'

--- a/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
@@ -1,0 +1,6 @@
+---
+
+base::mounts::assets_disks:
+  - '/dev/sdd'
+  - '/dev/sdf'
+  - '/dev/sdg'

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -10,3 +10,5 @@ PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('disable_class_parameter_defaults')
 # http://puppet-lint.com/checks/class_inherits_from_params_class/
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+# http://puppet-lint.com/checks/80chars/
+PuppetLint.configuration.send('disable_80chars')

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -10,5 +10,3 @@ PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('disable_class_parameter_defaults')
 # http://puppet-lint.com/checks/class_inherits_from_params_class/
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
-# http://puppet-lint.com/checks/80chars/
-PuppetLint.configuration.send('disable_80chars')

--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -7,7 +7,9 @@
 #
 # Always ensure `backup_data` directory exists
 
-class base::mounts {
+class base::mounts(
+  $assets_disks,
+){
 
     file { '/srv/backup-data':
         ensure =>   directory,
@@ -65,7 +67,6 @@ class base::mounts {
     }
 
     # lvm::volume { 'assets':
-    $assets_disks = [ '/dev/sdd', '/dev/sdf', '/dev/sdg', '/dev/sdh' ]
     $assets_vgname = 'assetsbackup'
     $assets_lvname = 'assets'
     physical_volume { $assets_disks:
@@ -74,11 +75,7 @@ class base::mounts {
     volume_group { $assets_vgname:
         ensure           => present,
         physical_volumes => $assets_disks,
-        require          => [ Physical_volume['/dev/sdd'],
-                              Physical_volume['/dev/sdf'],
-                              Physical_volume['/dev/sdg'],
-                              Physical_volume['/dev/sdh'],
-                            ],
+        require          => Physical_volume[$assets_disks],
     }
     logical_volume { $assets_lvname:
         ensure       => present,

--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -9,6 +9,7 @@
 
 class base::mounts(
   $assets_disks,
+  $graphite_disks,
 ){
 
     file { '/srv/backup-data':
@@ -101,19 +102,34 @@ class base::mounts(
         group   => 'govuk-backup',
     }
 
-    lvm::volume { 'graphite':
-        ensure  => present,
-        pv      => '/dev/sde',
-        vg      => 'graphitebackup',
-        fstype  => 'ext4',
+    # lvm::volume { 'graphite':
+    $graphite_vgname = 'graphitebackup'
+    $graphite_lvname = 'graphite'
+    physical_volume { $graphite_disks:
+        ensure => present,
     }
-
+    volume_group { $graphite_vgname:
+        ensure           => present,
+        physical_volumes => $graphite_disks,
+        require          => Physical_volume[$graphite_disks],
+    }
+    logical_volume { $graphite_lvname:
+        ensure       => present,
+        volume_group => $graphite_vgname,
+        require      => Volume_group[$graphite_vgname],
+    }
+    filesystem { "/dev/${graphite_vgname}/${graphite_lvname}":
+        ensure  => present,
+        fs_type => 'ext4',
+        require => Logical_volume[$graphite_lvname]
+    }
     ext4mount { '/srv/backup-graphite':
         mountoptions  => 'defaults',
         disk          => '/dev/mapper/graphitebackup-graphite',
         before        => File['/srv/backup-graphite'],
-        require       => Lvm::Volume['graphite'],
+        require       => Filesystem["/dev/${graphite_vgname}/${graphite_lvname}"],
     }
+    # } end lvm::volume
 
     file { '/srv/backup-graphite/tarballs':
         ensure  => directory,

--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -70,6 +70,7 @@ class base::mounts(
     # lvm::volume { 'assets':
     $assets_vgname = 'assetsbackup'
     $assets_lvname = 'assets'
+    $assets_fsname = "/dev/${assets_vgname}/${assets_lvname}"
     physical_volume { $assets_disks:
         ensure => present,
     }
@@ -83,7 +84,7 @@ class base::mounts(
         volume_group => $assets_vgname,
         require      => Volume_group[$assets_vgname],
     }
-    filesystem { "/dev/${assets_vgname}/${assets_lvname}":
+    filesystem { $assets_fsname:
         ensure  => present,
         fs_type => 'ext4',
         require => Logical_volume[$assets_lvname]
@@ -92,7 +93,7 @@ class base::mounts(
         mountoptions => 'defaults',
         disk         => "/dev/mapper/${assets_vgname}-${assets_lvname}",
         before       => File['/srv/backup-assets'],
-        require      => Filesystem["/dev/${assets_vgname}/${assets_lvname}"],
+        require      => Filesystem[$assets_fsname],
     }
     # } end lvm::volume
 
@@ -105,6 +106,7 @@ class base::mounts(
     # lvm::volume { 'graphite':
     $graphite_vgname = 'graphitebackup'
     $graphite_lvname = 'graphite'
+    $graphite_fsname = "/dev/${graphite_vgname}/${graphite_lvname}"
     physical_volume { $graphite_disks:
         ensure => present,
     }
@@ -118,7 +120,7 @@ class base::mounts(
         volume_group => $graphite_vgname,
         require      => Volume_group[$graphite_vgname],
     }
-    filesystem { "/dev/${graphite_vgname}/${graphite_lvname}":
+    filesystem { $graphite_fsname:
         ensure  => present,
         fs_type => 'ext4',
         require => Logical_volume[$graphite_lvname]
@@ -127,7 +129,7 @@ class base::mounts(
         mountoptions  => 'defaults',
         disk          => '/dev/mapper/graphitebackup-graphite',
         before        => File['/srv/backup-graphite'],
-        require       => Filesystem["/dev/${graphite_vgname}/${graphite_lvname}"],
+        require       => Filesystem[$graphite_fsname],
     }
     # } end lvm::volume
 

--- a/vcloud/box/common/bootstrap.erb
+++ b/vcloud/box/common/bootstrap.erb
@@ -1,26 +1,31 @@
 #!/bin/bash
 
 if [ $1 = "postcustomization" ]; then
-  echo 'ubuntu:<%= vars[:pass_hash] %>' | chpasswd -e 
-  
+  echo 'ubuntu:<%= vars[:pass_hash] %>' | chpasswd -e
+
   dpkg-reconfigure openssh-server
   set -e
   exec >/var/log/userdata.log 2>&1
   export DEBIAN_FRONTEND=noninteractive
   E="/etc/environment"
   echo "LC_ALL=en_GB.UTF-8" > $E
-  
-  R="/etc/resolv.conf"
-  echo "nameserver 8.8.8.8" >$R
-  echo "nameserver 8.8.4.4" >>$R
-  
+
+  <% if vars[:dns_suffix] %>
+    sed -i '/^127.0.1.1/d' /etc/hosts
+    sed -i '/^dns-search/d' /etc/network/interfaces
+    sed -i '/^dns-nameservers/d' /etc/network/interfaces
+    echo -e 'dns-search\t<%= vars[:dns_suffix] %>\ndns-nameservers\t8.8.8.8 8.8.4.4' >> /etc/network/interfaces
+    echo -e 'nameserver 8.8.8.8\nnameserver 8.8.4.4\nsearch <%= vars[:dns_suffix] %>' | resolvconf -a eth0.inet
+  <% end %>
+
+
   sed -i '/^deb cdrom/d' /etc/apt/sources.list
   wget http://apt.puppetlabs.com/puppetlabs-release-precise.deb
   dpkg -i puppetlabs-release-precise.deb
   apt-get update
-  
+
   export PATH=$PATH:/usr/local/bin
   apt-get -y install ruby1.9.3 puppet='3.4.*' puppet-common='3.4.*' facter='1.7.*'
   service puppet stop
-  
+
 fi

--- a/vcloud/box/skyscape/govuk_offsitebackups.yaml
+++ b/vcloud/box/skyscape/govuk_offsitebackups.yaml
@@ -1,6 +1,6 @@
 ---
 vapps:
-- name: 'offsite-backup-1'
+- name: 'backup0'
   vdc_name: 'GOV.UK Off-site Backups (IL2-PROD-STANDARD)'
   catalog_name: 'Packer'
   vapp_template_name: 'ubuntu_trusty64_20150707'

--- a/vcloud/box/skyscape/govuk_offsitebackups.yaml
+++ b/vcloud/box/skyscape/govuk_offsitebackups.yaml
@@ -1,0 +1,28 @@
+---
+vapps:
+- name: 'offsite-backup-1'
+  vdc_name: 'GOV.UK Off-site Backups (IL2-PROD-STANDARD)'
+  catalog_name: 'Packer'
+  vapp_template_name: 'ubuntu_trusty64_20150707'
+  vm:
+    hardware_config:
+      memory: '2048'
+      cpu: '2'
+    network_connections:
+    - name: Default
+      ip_address: '192.168.152.10'
+    extra_disks:
+    - name: backup-disk
+      size: 307200
+    - name: logs-disk
+      size: 524288
+    - name: assetsbackup-assets
+      size: 786432
+    - name: assetsbackup-assets2
+      size: 786432
+    - name: graphitebackup-graphite
+      size: 262144
+    bootstrap:
+        script_path: 'vcloud/box/common/bootstrap.erb'
+        vars:
+          pass_hash: '$6$/66cG1LV$F16Yn7DmFHL6Hkti8U0CBS9r7GtDT03KKsrdMVvVM79s2xONq9A4KdGEldozDanhsdgpg4ZzjWCwzOwxdCrWi0'


### PR DESCRIPTION
We are creating a new off-site backup machine in Skyscape in addition to the existing machine in Carrenza. The layout of the disks has changed because, over time, additional disks have been added to existing LVM volume groups on the Carrenza machine, and because we want to squash disks to increase performance (on the Skyscape SAN, a disk with more than 1.8tb will span LUNs; 1.8tb because there is an overhead on the 2tb total LUN size). Squashing disks also helps pay mitigate against https://github.com/gds-operations/vcloud-launcher/issues/104. We also get to increase disk size for Graphite backups, too.