### PR TITLE
Different disk layout per machine

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,5 +1,5 @@
 :hierarchy:
-  - "node.%{::clientcert}"
+  - "node.%{::fqdn}"
   - "env.%{::environment}"
   - common
 :backends:

--- a/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
@@ -1,0 +1,5 @@
+---
+
+base::mounts::assets_disks:
+  - '/dev/sdd'
+  - '/dev/sde'

--- a/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
@@ -3,3 +3,6 @@
 base::mounts::assets_disks:
   - '/dev/sdd'
   - '/dev/sde'
+
+base::mounts::graphite_disks:
+  - '/dev/sdf'

--- a/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
@@ -4,3 +4,7 @@ base::mounts::assets_disks:
   - '/dev/sdd'
   - '/dev/sdf'
   - '/dev/sdg'
+
+base::mounts::graphite_disks:
+  - '/dev/sde'
+  - '/dev/sdh'

--- a/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
@@ -1,0 +1,6 @@
+---
+
+base::mounts::assets_disks:
+  - '/dev/sdd'
+  - '/dev/sdf'
+  - '/dev/sdg'

--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -7,7 +7,9 @@
 #
 # Always ensure `backup_data` directory exists
 
-class base::mounts {
+class base::mounts(
+  $assets_disks,
+){
 
     file { '/srv/backup-data':
         ensure =>   directory,
@@ -64,8 +66,12 @@ class base::mounts {
         group   => 'govuk-assets',
     }
 
+    # FIXME: We currently unpack lvm::volume to work around MODULES-5
+    # (https://tickets.puppetlabs.com/browse/MODULES-5), however we should
+    # upgrade puppetlabs/lvm and re-use lvm::volume properly after this has
+    # been done.
+    #
     # lvm::volume { 'assets':
-    $assets_disks = [ '/dev/sdd', '/dev/sdf', '/dev/sdg', '/dev/sdh' ]
     $assets_vgname = 'assetsbackup'
     $assets_lvname = 'assets'
     physical_volume { $assets_disks:
@@ -74,11 +80,7 @@ class base::mounts {
     volume_group { $assets_vgname:
         ensure           => present,
         physical_volumes => $assets_disks,
-        require          => [ Physical_volume['/dev/sdd'],
-                              Physical_volume['/dev/sdf'],
-                              Physical_volume['/dev/sdg'],
-                              Physical_volume['/dev/sdh'],
-                            ],
+        require          => Physical_volume[$assets_disks],
     }
     logical_volume { $assets_lvname:
         ensure       => present,

--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -9,6 +9,7 @@
 
 class base::mounts(
   $assets_disks,
+  $graphite_disks,
 ){
 
     file { '/srv/backup-data':
@@ -106,18 +107,38 @@ class base::mounts(
         group   => 'govuk-backup',
     }
 
-    lvm::volume { 'graphite':
-        ensure  => present,
-        pv      => '/dev/sde',
-        vg      => 'graphitebackup',
-        fstype  => 'ext4',
+    # FIXME: We currently unpack lvm::volume to work around MODULES-5
+    # (https://tickets.puppetlabs.com/browse/MODULES-5), however we should
+    # upgrade puppetlabs/lvm and re-use lvm::volume properly after this has
+    # been done.
+    #
+    # lvm::volume { 'graphite':
+    $graphite_vgname = 'graphitebackup'
+    $graphite_lvname = 'graphite'
+    $graphite_fsname = "/dev/${graphite_vgname}/${graphite_lvname}"
+    physical_volume { $graphite_disks:
+      ensure => present,
     }
-
+    volume_group { $graphite_vgname:
+      ensure           => present,
+      physical_volumes => $graphite_disks,
+      require          => Physical_volume[$graphite_disks],
+    }
+    logical_volume { $graphite_lvname:
+      ensure       => present,
+      volume_group => $graphite_vgname,
+      require      => Volume_group[$graphite_vgname],
+    }
+    filesystem { $graphite_fsname:
+      ensure  => present,
+      fs_type => ext4,
+      require => Logical_volume[$graphite_lvname],
+    }
     ext4mount { '/srv/backup-graphite':
         mountoptions  => 'defaults',
         disk          => '/dev/mapper/graphitebackup-graphite',
         before        => File['/srv/backup-graphite'],
-        require       => Lvm::Volume['graphite'],
+        require       => Filesystem[$graphite_fsname],
     }
 
     file { '/srv/backup-graphite/tarballs':

--- a/vcloud/box/carrenza/govuk_offsitebackups.yaml
+++ b/vcloud/box/carrenza/govuk_offsitebackups.yaml
@@ -1,6 +1,6 @@
 ---
 vapps:
-- name: 'offsite-backup-1'
+- name: 'backup0'
   vdc_name: '0e7t-IS-OVDC-BACKUP'
   catalog_name: 'ubuntu'
   vapp_template_name: 'preseeded-540059de'

--- a/vcloud/box/common/bootstrap.erb
+++ b/vcloud/box/common/bootstrap.erb
@@ -1,26 +1,22 @@
 #!/bin/bash
 
 if [ $1 = "postcustomization" ]; then
-  echo 'ubuntu:<%= vars[:pass_hash] %>' | chpasswd -e 
-  
+  echo 'ubuntu:<%= vars[:pass_hash] %>' | chpasswd -e
+
   dpkg-reconfigure openssh-server
   set -e
   exec >/var/log/userdata.log 2>&1
   export DEBIAN_FRONTEND=noninteractive
   E="/etc/environment"
   echo "LC_ALL=en_GB.UTF-8" > $E
-  
-  R="/etc/resolv.conf"
-  echo "nameserver 8.8.8.8" >$R
-  echo "nameserver 8.8.4.4" >>$R
-  
+
   sed -i '/^deb cdrom/d' /etc/apt/sources.list
   wget http://apt.puppetlabs.com/puppetlabs-release-precise.deb
   dpkg -i puppetlabs-release-precise.deb
   apt-get update
-  
+
   export PATH=$PATH:/usr/local/bin
   apt-get -y install ruby1.9.3 puppet='3.4.*' puppet-common='3.4.*' facter='1.7.*'
   service puppet stop
-  
+
 fi

--- a/vcloud/box/skyscape/govuk_offsitebackups.yaml
+++ b/vcloud/box/skyscape/govuk_offsitebackups.yaml
@@ -1,6 +1,6 @@
 ---
 vapps:
-- name: 'offsite-backup-1'
+- name: 'backup0'
   vdc_name: 'GOV.UK Off-site Backups (IL2-PROD-STANDARD)'
   catalog_name: 'Packer'
   vapp_template_name: 'ubuntu_trusty64_20150707'

--- a/vcloud/box/skyscape/govuk_offsitebackups.yaml
+++ b/vcloud/box/skyscape/govuk_offsitebackups.yaml
@@ -1,0 +1,28 @@
+---
+vapps:
+- name: 'offsite-backup-1'
+  vdc_name: 'GOV.UK Off-site Backups (IL2-PROD-STANDARD)'
+  catalog_name: 'Packer'
+  vapp_template_name: 'ubuntu_trusty64_20150707'
+  vm:
+    hardware_config:
+      memory: '2048'
+      cpu: '2'
+    network_connections:
+    - name: Default
+      ip_address: '192.168.152.10'
+    extra_disks:
+    - name: backup-disk
+      size: 307200
+    - name: logs-disk
+      size: 524288
+    - name: assetsbackup-assets
+      size: 786432
+    - name: assetsbackup-assets2
+      size: 786432
+    - name: graphitebackup-graphite
+      size: 262144
+    bootstrap:
+        script_path: 'vcloud/box/common/bootstrap.erb'
+        vars:
+          pass_hash: '$6$/66cG1LV$F16Yn7DmFHL6Hkti8U0CBS9r7GtDT03KKsrdMVvVM79s2xONq9A4KdGEldozDanhsdgpg4ZzjWCwzOwxdCrWi0'


### PR DESCRIPTION
Ultimately, this pull request allows us to specify disk layouts to use on a per-machine basis, by specifying Hieradata in `hieradata/` named after the FQDN of the machine itself.

When adding a new off-site backup target in Skyscape, we realised that we had eight disks. Disks are added as a result of trying to increase space on existing backup machines. The problem with eight disks is that, given the SCSI Controller addresses the first disk as disk 0, the eighth disk becomes disk 7. This means that we run in to https://github.com/gds-operations/vcloud-launcher/issues/104 when we try to deploy machines with seven or more disks.

To work around this, and in order to make more efficient use of disks on hosts, we should squash disks together. The real resolution will hopefully be a fix to the above issue, but this is a short-term fix to get things working. We're also adding additional space to some volume groups, such as the `graphite` one since they were getting low on space. You'll also see that some volume groups are stretched across physical volumes - this is because the recommended maximum disk size per LUN is 2tb, in order to ensure that the disk isn't stretched across LUNs which reduces performance.