### PR TITLE
Split out provider setting in to separate tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ original glory once it has the chance to run successfully.
 If it's not the first time you are applying this repository to a machine, you
 can run:
 
-    fab -c /dev/null -u YOUR_SSH_USERNAME production <provider> deploy
+    fab -c /dev/null -u <username> production <provider> deploy
 
 `provider` needs to be set to either:
   - `provider0` for Skyscape

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ codebase.
 If this is the first time that this repository is being applied to a machine,
 you need to run:
 
-    fab -c /dev/null production firstrun
+    fab -c /dev/null production <provider> firstrun
+
+`provider` needs to be set to either:
+  - `provider0` for Skyscape
+  - `provider1` for Carrenza
 
 This `firstrun` task is to allow rsync to start up correctly, without
 requiring either an askpass helper or a TTY in which to collect the ubuntu
@@ -36,4 +40,8 @@ original glory once it has the chance to run successfully.
 If it's not the first time you are applying this repository to a machine, you
 can run:
 
-    fab -c /dev/null -u YOUR_SSH_USERNAME production deploy
+    fab -c /dev/null -u YOUR_SSH_USERNAME production <provider> deploy
+
+`provider` needs to be set to either:
+  - `provider0` for Skyscape
+  - `provider1` for Carrenza

--- a/fabfile.py
+++ b/fabfile.py
@@ -16,9 +16,16 @@ env.repo = 'git://github.com/alphagov/govuk_offsitebackups-puppet.git'
 @runs_once
 def production():
     env.environment = 'production'
-    env.hosts = [
-        'backup0.backup.provider1.production.govuk.service.gov.uk',
-        ]
+
+@task
+@runs_once
+def provider0():
+    env.hosts = 'backup0.backup.provider0.production.govuk.service.gov.uk'
+
+@task
+@runs_once
+def provider1():
+    env.hosts = 'backup0.backup.provider1.production.govuk.service.gov.uk'
 
 @task
 @runs_once


### PR DESCRIPTION
As it stands, the fabfile allowed us to set the environment we wish to run
a task in, however since the hosts chosen would be part of an array, the
task would be run against all hosts.

In order to allow for tasks to be run against specific hosts, separate the
setting of `env.hosts` out in to different tasks which can be chosen at
runtime.

Amends README to clarify this.