### PR TITLE
Test Ruby 2.1.5 with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,3 @@
 language: ruby
-# Ignore lock file to facilitate matrix builds.
-before_install: rm Gemfile.lock
 # Explicitly ensure that we run on container-based infrastructure
 sudo: false
-rvm:
-  - 1.9.3
-  - ruby-head
-matrix:
-  allow_failures:
-    - rvm: ruby-head


### PR DESCRIPTION
Ruby 2.1.5 is the version that we're using in the `.ruby-version` file, so there's no point in testing anything else.