### PR TITLE
Remove Skyscape IP address from NRPE hosts

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -74,7 +74,6 @@ base::user::logs_ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQDEBXBO6UU0zkOM+RL3TTir0Z
 
 nrpe::allowed_hosts:
   - 127.0.0.1
-  - 37.26.90.227
   - 31.210.245.86
 
 # Carrenza nameservers.


### PR DESCRIPTION
We no longer have a monitoring machine in Skyscape, so remove the IP
address for Skyscape Production.