### PR TITLE
Upgrade UFW module to lastest on Puppet Forge

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,7 +1,7 @@
 forge 'http://forge.puppetlabs.com/'
 
 mod 'attachmentgenie/ssh', '~> 1.1.1'
-mod 'attachmentgenie/ufw'
+mod 'attachmentgenie/ufw', '1.4.9'
 mod 'blom/rssh'
 mod 'gdsoperations/resolvconf'
 mod 'pdxcat/nrpe'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -8,7 +8,7 @@ FORGE
   specs:
     attachmentgenie/ssh (1.1.2)
       puppetlabs/stdlib (>= 2.2.1)
-    attachmentgenie/ufw (1.4.7)
+    attachmentgenie/ufw (1.4.9)
       puppetlabs/stdlib (>= 2.2.1)
     blom/rssh (0.0.3)
     gdsoperations/resolvconf (0.3.1)
@@ -16,7 +16,7 @@ FORGE
     pdxcat/nrpe (1.0.0)
     puppetlabs/apt (1.4.2)
       puppetlabs/stdlib (>= 2.2.1)
-    puppetlabs/stdlib (3.2.1)
+    puppetlabs/stdlib (3.2.2)
     saz/sudo (3.0.1)
       puppetlabs/stdlib (>= 2.3.0)
 
@@ -52,7 +52,7 @@ GIT
 
 DEPENDENCIES
   attachmentgenie/ssh (~> 1.1.1)
-  attachmentgenie/ufw (>= 0)
+  attachmentgenie/ufw (= 1.4.9)
   blom/rssh (>= 0)
   ext4mount (>= 0)
   gds_accounts (>= 0)

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -77,7 +77,7 @@ rssh::allow:
   - scp
   - sftp
 
-ufw::allows:
+ufw::allow:
   ssh:
     port: 22
     ip: any


### PR DESCRIPTION
The class parameters for `ufw` changed to use `allow` rather than
`allows` in:
https://github.com/attachmentgenie/attachmentgenie-ufw/commit/72aa574f3daf81437779434ed741bff21f69bef1:

So that we don't forget to change the Hiera data if we upgrade this
module in future, upgrade the module now and correct the Hiera data key
accordingly.