### PR TITLE
Remove hyphen from CDN logs LVM name

### DIFF
--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -156,18 +156,27 @@ class base::mounts(
           group  => 'govuk-backup',
       }
 
-      lvm::volume { 'cdn-logs':
+      lvm::volume { 'cdnlogs':
           ensure => present,
           pv     => '/dev/sdg',
           vg     => 'cdnlogsbackup',
           fstype => 'ext4',
       }
 
+      # FIXME: Remove once deployed
+      lvm::volume { 'cdn-logs':
+          ensure => absent,
+          pv     => '/dev/sdg',
+          vg     => 'cdnlogsbackup',
+          fstype => 'ext4',
+          before => Lvm::Volume['cdnlogs'],
+      }
+
       ext4mount { '/srv/backup-cdn-logs':
           mountoptions => 'defaults',
-          disk         => '/dev/mapper/cdnlogsbackup-cdn-logs',
+          disk         => '/dev/mapper/cdnlogsbackup-cdnlogs',
           before       => File['/srv/backup-cdn-logs'],
-          require      => Lvm::Volume['cdn-logs'],
+          require      => Lvm::Volume['cdnlogs'],
       }
     }
 


### PR DESCRIPTION
__Story: https://trello.com/c/xbsYTau0/33-back-up-processed-cdn-logs__

LVM will double any hyphens in a volume name, so the LVM device was
being created at:

    /dev/mapper/cdnlogsbackup-cdn--logs

...which causes the ext4mount resource to fail:

    [backup0.backup.provider0.production.govuk.service.gov.uk] out: Notice: /Stage[main]/Base::Mounts/Ext4mount[/srv/backup-cdn-logs]/Exec[disk-/dev/mapper/cdnlogsbackup-cdn-logs-exists]/returns: /sbin/e2label: No such file or directory while trying to open /dev/mapper/cdnlogsbackup-cdn-logs
    [backup0.backup.provider0.production.govuk.service.gov.uk] out: Notice: /Stage[main]/Base::Mounts/Ext4mount[/srv/backup-cdn-logs]/Exec[disk-/dev/mapper/cdnlogsbackup-cdn-logs-exists]/returns: Couldn't find valid filesystem superblock.
    [backup0.backup.provider0.production.govuk.service.gov.uk] out: Error: /sbin/e2label /dev/mapper/cdnlogsbackup-cdn-logs returned 1 instead of one of [0]
    [backup0.backup.provider0.production.govuk.service.gov.uk] out: Error: /Stage[main]/Base::Mounts/Ext4mount[/srv/backup-cdn-logs]/Exec[disk-/dev/mapper/cdnlogsbackup-cdn-logs-exists]/returns: change from notrun to 0 failed: /sbin/e2label /dev/mapper/cdnlogsbackup-cdn-logs returned 1 instead of one of [0]
    [backup0.backup.provider0.production.govuk.service.gov.uk] out: Notice: /Stage[main]/Base::Mounts/Ext4mount[/srv/backup-cdn-logs]/Mount[mount-/srv/backup-cdn-logs]: Dependency Exec[disk-/dev/mapper/cdnlogsbackup-cdn-logs-exists] has failures: true

This behaviour doesn't seem to be well documented, however I found a
reference to it here in a change to the `dmsetup` man page:
https://www.redhat.com/archives/lvm-devel/2014-June/msg00170.html