### PR TITLE
Remove deprecated LVM volume

### DIFF
--- a/modules/base/manifests/mounts.pp
+++ b/modules/base/manifests/mounts.pp
@@ -163,15 +163,6 @@ class base::mounts(
           fstype => 'ext4',
       }
 
-      # FIXME: Remove once deployed
-      lvm::volume { 'cdn-logs':
-          ensure => absent,
-          pv     => '/dev/sdg',
-          vg     => 'cdnlogsbackup',
-          fstype => 'ext4',
-          before => Lvm::Volume['cdnlogs'],
-      }
-
       ext4mount { '/srv/backup-cdn-logs':
           mountoptions => 'defaults',
           disk         => '/dev/mapper/cdnlogsbackup-cdnlogs',


### PR DESCRIPTION
Remove the deprecated `cdn-logs` LVM volume because `dmsetup` fails when
we try to remove it.

I believe this is because the volume was created with a double hyphen in
the name (see 6f06d7df) and `dmsetup` is not including the double hyphen
when removing the volume.

    [backup0.backup.provider0.production.govuk.service.gov.uk] out: Error: Execution of '/sbin/dmsetup remove cdnlogsbackup-cdn-logs' returned 1: device-mapper: remove ioctl on cdnlogsbackup-cdn-logs failed: No such device or address
    [backup0.backup.provider0.production.govuk.service.gov.uk] out: Command failed
    [backup0.backup.provider0.production.govuk.service.gov.uk] out:
    [backup0.backup.provider0.production.govuk.service.gov.uk] out: Error: /Stage[main]/Base::Mounts/Lvm::Volume[cdn-logs]/Logical_volume[cdn-logs]/ensure: change from present to absent failed: Execution of '/sbin/dmsetup remove cdnlogsbackup-cdn-logs' returned 1: device-mapper: remove ioctl on cdnlogsbackup-cdn-logs failed: No such device or address
    [backup0.backup.provider0.production.govuk.service.gov.uk] out: Command failed
    [backup0.backup.provider0.production.govuk.service.gov.uk] out:

/cc @deanwilson 