### PR TITLE
Update disks for cdnlogs

### DIFF
--- a/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
@@ -7,4 +7,8 @@ base::mounts::assets_disks:
 base::mounts::graphite_disks:
   - '/dev/sdf'
 
+base::mounts::cdnlogs_disks:
+  - '/dev/sdc'
+  - '/dev/sdg'
+
 base::mounts::cdn_logs: true

--- a/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider1.production.govuk.service.gov.uk.yaml
@@ -8,3 +8,5 @@ base::mounts::assets_disks:
 base::mounts::graphite_disks:
   - '/dev/sde'
   - '/dev/sdh'
+
+base::mounts::transition_logs_backup: true


### PR DESCRIPTION
In provider0, the mount point `/srv/backup-cdn-logs` has used it's full 60G worth of disk and will probably continue to rise.

`/srv/backup-logs` has used none of it's 500G and will not be used in the foreseeable future.

This change seeks to remove the directory and logical volume for backup-logs and add the disk for use with backup-cdn-logs.