### PR TITLE
Download modules from Forge over HTTPS

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,4 +1,4 @@
-forge 'http://forge.puppetlabs.com/'
+forge 'https://forge.puppet.com/'
 
 mod 'attachmentgenie/ssh', '~> 1.1.1'
 mod 'attachmentgenie/ufw', '1.4.9'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -4,7 +4,7 @@ FORGE
     torrancew/account (0.0.5)
 
 FORGE
-  remote: http://forge.puppetlabs.com/
+  remote: https://forge.puppet.com/
   specs:
     attachmentgenie/ssh (1.1.2)
       puppetlabs/stdlib (>= 2.2.1)


### PR DESCRIPTION
Puppet Forge now redirects from HTTP to HTTPS which breaks librarian-puppet. We should have been using HTTPS to begin with.