### PR TITLE
Add another disk to backup0.provider0

### DIFF
--- a/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
+++ b/hieradata/node.backup0.backup.provider0.production.govuk.service.gov.uk.yaml
@@ -3,6 +3,7 @@
 base::mounts::assets_disks:
   - '/dev/sdd'
   - '/dev/sde'
+  - '/dev/sdh'
 
 base::mounts::graphite_disks:
   - '/dev/sdf'

--- a/vcloud/box/skyscape/govuk_offsitebackups.yaml
+++ b/vcloud/box/skyscape/govuk_offsitebackups.yaml
@@ -24,6 +24,8 @@ vapps:
       size: 262144
     - name: cdn-logs
       size: 65536
+    - name: assetsbackup-assets3
+      size: 786432
     bootstrap:
         script_path: 'vcloud/box/common/bootstrap.erb'
         vars:


### PR DESCRIPTION
This mount is running out of disk space. The job is meant to store two full backups of a 600GB dataset, but only has 1.5TB of disk space. It does the cleanup task *after* it has taken the third full backup, so it actually runs out of space during the backup and never does the cleanup task.

The other option to fix this problem in the short term is to reduce the amount of full backups we keep.